### PR TITLE
Add Azure AD authentication support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@
 FROM mitmproxy/mitmproxy:10.0.0
 
 # 安装任何额外的依赖项（如果需要）
-RUN pip install mitmproxy elasticsearch asyncio
+RUN pip install mitmproxy elasticsearch asyncio azure-identity azure-keyvault-secrets
 
 # 在生产环境中，建议将配置通过Volume 挂载方式挂载到容器中，这样可以方便的修改配置；
 # 将您的脚本添加到容器中, 建议可以采用docker -v 将脚本挂载到容器中
 # COPY proxy-es.py /app/proxy-es.py
 # 将您的proxy 用户名密码本加到容器中，建议可以采用docker -v 将密码本文件挂载到容器中
-# COPY creds.txt /app/creds.txt
 # 将您的 mitmproxy 的证书加到容器中，建议可以采用docker -v 将证书挂载到容器中
 # COPY ./certs /opt/mitmproxy
 


### PR DESCRIPTION
Fixes #22

Add support for Azure AD integration for authentication.

* **proxy-es.py**:
  - Import necessary Azure AD libraries.
  - Replace the `load_credentials` method with Azure AD authentication logic.
  - Update the `http_connect` method to use Azure AD for authentication.
  - Remove the `creds.txt` file reference and related logic.

* **Dockerfile**:
  - Add installation of Azure AD libraries in the `RUN` command.
  - Remove the `COPY creds.txt` line.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickhou1983/mitmproxy-copilot/issues/22?shareId=f8e48840-c2e4-4943-9a61-88729f7e24df).