### PR TITLE
Integrate Azure AD authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM mitmproxy/mitmproxy:10.0.0
 
 # 安装任何额外的依赖项（如果需要）
-RUN pip install mitmproxy elasticsearch asyncio
+RUN pip install mitmproxy elasticsearch asyncio msal
 
 # 在生产环境中，建议将配置通过Volume 挂载方式挂载到容器中，这样可以方便的修改配置；
 # 将您的脚本添加到容器中, 建议可以采用docker -v 将脚本挂载到容器中
@@ -17,4 +17,3 @@ WORKDIR /app
 
 # 设置mitmproxy的启动命令，使用您的脚本作为参数
 CMD ["mitmdump","--set", "confdir=/opt/mitmproxy","-s", "proxy-es.py", "-p", "8080", "--listen-host", "0.0.0.0", "--set",  "block_global=false"]
-

--- a/README.md
+++ b/README.md
@@ -75,3 +75,28 @@ certutil -addstore root mitmproxy-ca-cert.cer
 * Http:Proxy 采用如下格式：*http://用户名:密码@代理服务器地址:代理服务器端口*
 * Http: Proxy Strict SSL 启用后，IDE会检查Mitmproxy代理服务器的证书。禁用后，IDE 不会检查Mitmproxy代理服务器的证书；
 
+### 配置Azure AD集成
+
+1. 在Azure门户中注册一个新的应用程序，并记下应用程序(客户端)ID、目录(租户)ID和客户端密码。
+
+2. 在`proxy-es.py`文件中，设置以下Azure AD配置参数：
+```python
+TENANT_ID = "your_tenant_id"
+CLIENT_ID = "your_client_id"
+CLIENT_SECRET = "your_client_secret"
+AUTHORITY = f"https://login.microsoftonline.com/{TENANT_ID}"
+SCOPE = ["User.Read"]
+```
+
+3. 确保在`Dockerfile`中安装了`msal`库：
+```dockerfile
+RUN pip install msal
+```
+
+4. 构建并运行Docker容器：
+```
+docker build . -t mitmproxy-copilot:v1
+docker run -d --net="host" mitmproxy-copilot:v1 -v ./proxy-es.py:/app/proxy-es.py
+```
+
+5. 现在，代理服务器将使用Azure AD进行身份验证。

--- a/aks-deployment.yaml
+++ b/aks-deployment.yaml
@@ -18,6 +18,13 @@ spec:
         volumeMounts:
         - name: mitmproxy-volume
           mountPath: /app
+        env:
+        - name: TENANT_ID
+          value: "your_tenant_id"
+        - name: CLIENT_ID
+          value: "your_client_id"
+        - name: CLIENT_SECRET
+          value: "your_client_secret"
       volumes:
       - name: mitmproxy-volume
         persistentVolumeClaim:

--- a/proxy-es.py
+++ b/proxy-es.py
@@ -7,6 +7,7 @@ import re
 import os
 import json
 import functools
+import msal
 
 # 通常仅需要修改这里的配置
 # 初始化Elasticsearch客户端，如果Elasticsearch需要身份验证，可以在这里设置用户名和密码
@@ -48,11 +49,13 @@ allowed_patterns = [
      "https://api.github.com/.*"
 ]
 
-# 身份验证函数
-# def authenticate(username, password):
-#     # 在这里实现你的身份验证逻辑
-#     # 返回True表示验证通过，False表示验证失败
-#     return username == password
+# Azure AD 配置参数
+TENANT_ID = "your_tenant_id"
+CLIENT_ID = "your_client_id"
+CLIENT_SECRET = "your_client_secret"
+AUTHORITY = f"https://login.microsoftonline.com/{TENANT_ID}"
+SCOPE = ["User.Read"]
+
 def is_url_allowed(url: str) -> bool:
     for pattern in allowed_patterns:
         if re.match(pattern, url):
@@ -63,17 +66,11 @@ class AuthProxy:
     def __init__(self):
         self.loop = asyncio.get_event_loop()
         self.proxy_authorizations = {} 
-        self.credentials = self.load_credentials("creds.txt")
-
-    def load_credentials(self, file_path):
-        if not os.path.exists(file_path):
-            raise FileNotFoundError(f"Credentials file '{file_path}' not found")
-        creds = {}
-        with open(file_path, "r") as f:
-            for line in f:
-                username, password = line.strip().split(",")
-                creds[username] = password
-        return creds
+        self.msal_app = msal.ConfidentialClientApplication(
+            CLIENT_ID,
+            authority=AUTHORITY,
+            client_credential=CLIENT_SECRET,
+        )
 
     def http_connect(self, flow: http.HTTPFlow):
         proxy_auth = flow.request.headers.get("Proxy-Authorization", "")
@@ -83,27 +80,20 @@ class AuthProxy:
         ctx.log.info("Proxy-Authorization: " + proxy_auth.strip())
         if proxy_auth.strip() == "" :
             flow.response = http.Response.make(401)
-        #    self.proxy_authorizations[(flow.client_conn.address[0])] = "daniel"
-        #    return
         auth_type, auth_string = proxy_auth.split(" ", 1)
         auth_string = base64.b64decode(auth_string).decode("utf-8")
         username, password = auth_string.split(":")
         ctx.log.info("User: " + username + " Password: " + password)
-        # 验证用户名和密码
-        if username in self.credentials:
-            # If the username exists, check if the password is correct
-            if self.credentials[username] != password:
-                ctx.log.info("User: " + username + " attempted to log in with an incorrect password.")
-                flow.response = http.Response.make(401)
-                return
+        
+        # 使用MSAL进行Azure AD身份验证
+        result = self.msal_app.acquire_token_for_client(scopes=SCOPE)
+        if "access_token" in result:
+            ctx.log.info("Authenticated: " + flow.client_conn.address[0])
+            self.proxy_authorizations[(flow.client_conn.address[0])] = username
         else:
-            # If the username does not exist, log the event and return a 401 response
-            ctx.log.info("Username: " + username + " does not exist.")
+            ctx.log.info("Authentication failed for user: " + username)
             flow.response = http.Response.make(401)
             return
-        ctx.log.info("Authenticated: " + flow.client_conn.address[0])
-        self.proxy_authorizations[(flow.client_conn.address[0])] = username
-    
     
     def request(self, flow: http.HTTPFlow):
         if not is_url_allowed(flow.request.url):


### PR DESCRIPTION
Fixes #27

Integrate Azure AD authentication into the proxy server.

* **proxy-es.py**
  - Import the `msal` library for Azure AD authentication.
  - Add Azure AD configuration parameters.
  - Implement Azure AD authentication logic in the `http_connect` method.
  - Remove the existing credentials file-based authentication logic.

* **Dockerfile**
  - Install the `msal` library using `pip`.

* **README.md**
  - Add instructions for configuring Azure AD integration.

* **aks-deployment.yaml**
  - Add environment variables for Azure AD configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickhou1983/mitmproxy-copilot/issues/27?shareId=7bf3aa6b-1662-4aed-9151-ed1457636254).