### PR TITLE
Add Azure AD authentication and remove other methods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@
 FROM mitmproxy/mitmproxy:10.0.0
 
 # 安装任何额外的依赖项（如果需要）
-RUN pip install mitmproxy elasticsearch asyncio
+RUN pip install mitmproxy elasticsearch asyncio azure-identity azure-keyvault-secrets
 
 # 在生产环境中，建议将配置通过Volume 挂载方式挂载到容器中，这样可以方便的修改配置；
 # 将您的脚本添加到容器中, 建议可以采用docker -v 将脚本挂载到容器中
 # COPY proxy-es.py /app/proxy-es.py
-# 将您的proxy 用户名密码本加到容器中，建议可以采用docker -v 将密码本文件挂载到容器中
-# COPY creds.txt /app/creds.txt
 # 将您的 mitmproxy 的证书加到容器中，建议可以采用docker -v 将证书挂载到容器中
 # COPY ./certs /opt/mitmproxy
 
@@ -17,4 +15,3 @@ WORKDIR /app
 
 # 设置mitmproxy的启动命令，使用您的脚本作为参数
 CMD ["mitmdump","--set", "confdir=/opt/mitmproxy","-s", "proxy-es.py", "-p", "8080", "--listen-host", "0.0.0.0", "--set",  "block_global=false"]
-

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 
 1. Dockerfile 用于生成 mitmproxy-copilot 镜像；
 2. proxy-es.py 用于在mitmproxy中使用elasticsearch存储数据，可以通过此脚本对mitmproxy进行扩展；
-3. creds.txt 用于存储用户名和密码，用于mitmproxy的认证，和记录访问的用户名；
-4. 可以通过对proxy-es.py进行修改，实现更多的功能；
+3. 可以通过对proxy-es.py进行修改，实现更多的功能；
 
 
 
@@ -47,7 +46,7 @@ docker build . -t mitmproxy-copilot:v1
 
 3. 运行容器
 ```
-docker run -d --net="host" mitmproxy-copilot:v1 -v ./creds.txt:/app/creds.txt -v ./proxy-es.py:/app/proxy-es.py
+docker run -d --net="host" mitmproxy-copilot:v1 -v ./proxy-es.py:/app/proxy-es.py
 ```
 ### 已知问题
 

--- a/creds.txt
+++ b/creds.txt
@@ -1,1 +1,0 @@
-qifenghou_microsoft,123456

--- a/proxy-es.py
+++ b/proxy-es.py
@@ -50,11 +50,6 @@ allowed_patterns = [
      "https://api.github.com/.*"
 ]
 
-# 身份验证函数
-# def authenticate(username, password):
-#     # 在这里实现你的身份验证逻辑
-#     # 返回True表示验证通过，False表示验证失败
-#     return username == password
 def is_url_allowed(url: str) -> bool:
     for pattern in allowed_patterns:
         if re.match(pattern, url):
@@ -65,20 +60,9 @@ class AuthProxy:
     def __init__(self):
         self.loop = asyncio.get_event_loop()
         self.proxy_authorizations = {} 
-        self.credentials = self.load_credentials("creds.txt")
         self.azure_credential = DefaultAzureCredential()
         self.key_vault_url = "https://<your-key-vault-name>.vault.azure.net/"
         self.secret_client = SecretClient(vault_url=self.key_vault_url, credential=self.azure_credential)
-
-    def load_credentials(self, file_path):
-        if not os.path.exists(file_path):
-            raise FileNotFoundError(f"Credentials file '{file_path}' not found")
-        creds = {}
-        with open(file_path, "r") as f:
-            for line in f:
-                username, password = line.strip().split(",")
-                creds[username] = password
-        return creds
 
     def get_azure_secret(self, secret_name):
         secret = self.secret_client.get_secret(secret_name)
@@ -98,25 +82,17 @@ class AuthProxy:
         auth_string = base64.b64decode(auth_string).decode("utf-8")
         username, password = auth_string.split(":")
         ctx.log.info("User: " + username + " Password: " + password)
-        # 验证用户名和密码
-        if username in self.credentials:
-            # If the username exists, check if the password is correct
-            if self.credentials[username] != password:
+        # Check Azure AD for the username
+        try:
+            azure_password = self.get_azure_secret(username)
+            if azure_password != password:
                 ctx.log.info("User: " + username + " attempted to log in with an incorrect password.")
                 flow.response = http.Response.make(401)
                 return
-        else:
-            # Check Azure AD for the username
-            try:
-                azure_password = self.get_azure_secret(username)
-                if azure_password != password:
-                    ctx.log.info("User: " + username + " attempted to log in with an incorrect password.")
-                    flow.response = http.Response.make(401)
-                    return
-            except Exception as e:
-                ctx.log.info("Azure AD authentication failed for user: " + username)
-                flow.response = http.Response.make(401)
-                return
+        except Exception as e:
+            ctx.log.info("Azure AD authentication failed for user: " + username)
+            flow.response = http.Response.make(401)
+            return
         ctx.log.info("Authenticated: " + flow.client_conn.address[0])
         self.proxy_authorizations[(flow.client_conn.address[0])] = username
     
@@ -227,5 +203,4 @@ class AuthProxy:
 addons = [
     AuthProxy()
 ]
-
 


### PR DESCRIPTION
Fixes #39

Add support for Azure AD authentication and remove other authentication methods.

* **proxy-es.py**
  - Remove local credentials loading and authentication logic.
  - Ensure Azure AD authentication is the only method used.
  - Remove references to `creds.txt`.

* **README.md**
  - Update authentication section to reflect Azure AD usage.
  - Remove references to `creds.txt`.

* **Dockerfile**
  - Remove references to `creds.txt`.
  - Add installation of Azure AD dependencies.

* **creds.txt**
  - Delete file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickhou1983/mitmproxy-copilot/pull/40?shareId=55c3ff8c-c04f-4d02-839e-dc0588994383).